### PR TITLE
Fix -Wformat warning

### DIFF
--- a/spi_boards.c
+++ b/spi_boards.c
@@ -187,7 +187,7 @@ void spi_boards_scan(board_access_t *access) {
     }
 
     if(memcmp(buf, cookie, sizeof(cookie))) {
-        fprintf(stderr, "Unexpected cookie at %04x..%04x:\n%08x %08x %08x\n",
+        fprintf(stderr, "Unexpected cookie at %04x..%04lx:\n%08x %08x %08x\n",
             HM2_COOKIE_REG, HM2_COOKIE_REG + sizeof(buf),
             buf[0], buf[1], buf[2]);
         return;


### PR DESCRIPTION
Fixes:
 pi_boards.c:190:56: warning: format '%x' expects argument of type
 'unsigned int', but argument 4 has type 'long unsigned int' [-Wformat=]
   190 |         fprintf(stderr, "Unexpected cookie at %04x..%04x:\n%08x %08x %08x\n",
       |                                                     ~~~^
       |                                                        |
       |                                                        unsigned int
       |                                                     %04lx

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>