### PR TITLE
Fix linking errors

### DIFF
--- a/lbp.c
+++ b/lbp.c
@@ -28,7 +28,7 @@
 #include "lbp.h"
 
 #ifdef __linux__
-int sd;
+static int sd = -1;
 #elif _WIN32
 HANDLE sd;
 #endif

--- a/serial_boards.c
+++ b/serial_boards.c
@@ -35,7 +35,7 @@
 extern board_t boards[MAX_BOARDS];
 extern int boards_count;
 
-int sd;
+static int sd = -1;
 
 // serial access functions
 

--- a/spi_boards.c
+++ b/spi_boards.c
@@ -36,9 +36,9 @@
 extern board_t boards[MAX_BOARDS];
 extern int boards_count;
 
-bool canDo32 = true;
+static bool canDo32 = true;
 
-int sd = -1;
+static int sd = -1;
 struct spi_ioc_transfer settings;
 
 static int spidev_set_lsb_first(int fd, u8 lsb_first) {


### PR DESCRIPTION
Fixes the following linking errors on gcc 10:
/usr/bin/ld: libanyio.a(spi_boards.o):spi_boards.c:41:
 multiple definition of `sd';
 libanyio.a(eth_boards.o):eth_boards.c:49: first defined here
/usr/bin/ld: libanyio.a(serial_boards.o):serial_boards.c:38:
 multiple definition of `sd';
 libanyio.a(eth_boards.o):eth_boards.c:49: first defined here
/usr/bin/ld: libanyio.a(lbp.o):mesaflash/lbp.c:31:
 multiple definition of `sd';
 libanyio.a(eth_boards.o):eth_boards.c:49: first defined here

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>