### PR TITLE
Fix -Wstringop-truncation warnings

### DIFF
--- a/eth_boards.c
+++ b/eth_boards.c
@@ -144,7 +144,7 @@ static int eth_scan_one_addr(board_access_t *access) {
     recv = lbp16_recv_packet(&cookie, sizeof(cookie));
 
     if ((recv > 0) && (cookie == HM2_COOKIE)) {
-        char buff[20];
+        char buff[16];
         board_t *board = &boards[boards_count];
 
         board_init_struct(board);

--- a/pci_boards.c
+++ b/pci_boards.c
@@ -848,7 +848,7 @@ void pci_boards_scan(board_access_t *access) {
             board_init_struct(board);
             if ((dev->vendor_id == VENDORID_XIO2001) && (dev->device_id == DEVICEID_XIO2001)) {
                 board->type = BOARD_PCI;
-                strncpy(board->llio.board_name, "6I25 (RECOVER)", 14);
+                strcpy(board->llio.board_name, "6I25 (RECOVER)");
                 board->llio.num_ioport_connectors = 2;
                 board->llio.pins_per_connector = 17;
                 board->llio.ioport_connector_name[0] = "P3";
@@ -882,7 +882,7 @@ void pci_boards_scan(board_access_t *access) {
         if (dev->vendor_id == VENDORID_MESAPCI) {
             if (dev->device_id == DEVICEID_MESA4I74) {
                 board->type = BOARD_PCI;
-                strncpy((char *) board->llio.board_name, "4I74", 4);
+                strcpy((char *) board->llio.board_name, "4I74");
                 board->llio.num_ioport_connectors = 3;
                 board->llio.pins_per_connector = 24;
                 board->llio.ioport_connector_name[0] = "P1";
@@ -909,7 +909,7 @@ void pci_boards_scan(board_access_t *access) {
                 boards_count++;
             } else if (dev->device_id == DEVICEID_MESA5I24) {
                 board->type = BOARD_PCI;
-                strncpy((char *) board->llio.board_name, "5I24", 4);
+                strcpy(board->llio.board_name, "5I24");
                 board->llio.num_ioport_connectors = 3;
                 board->llio.pins_per_connector = 24;
                 board->llio.ioport_connector_name[0] = "P4";
@@ -937,7 +937,7 @@ void pci_boards_scan(board_access_t *access) {
                 boards_count++;
             } else if (dev->device_id == DEVICEID_MESA5I25) {
                 board->type = BOARD_PCI;
-                strncpy((char *) board->llio.board_name, "5I25", 4);
+                strcpy(board->llio.board_name, "5I25");
                 board->llio.num_ioport_connectors = 2;
                 board->llio.pins_per_connector = 17;
                 board->llio.ioport_connector_name[0] = "P3";
@@ -964,7 +964,7 @@ void pci_boards_scan(board_access_t *access) {
                 boards_count++;
             } else if (dev->device_id == DEVICEID_MESA6I24) {
                 board->type = BOARD_PCI;
-                strncpy((char *) board->llio.board_name, "6I24", 4);
+                strcpy(board->llio.board_name, "6I24");
                 board->llio.num_ioport_connectors = 3;
                 board->llio.pins_per_connector = 24;
                 board->llio.ioport_connector_name[0] = "P4";
@@ -992,7 +992,7 @@ void pci_boards_scan(board_access_t *access) {
                 boards_count++;
             } else if (dev->device_id == DEVICEID_MESA6I25) {
                 board->type = BOARD_PCI;
-                strncpy(board->llio.board_name, "6I25", 4);
+                strcpy(board->llio.board_name, "6I25");
                 board->llio.num_ioport_connectors = 2;
                 board->llio.pins_per_connector = 17;
                 board->llio.ioport_connector_name[0] = "P3";
@@ -1023,7 +1023,7 @@ void pci_boards_scan(board_access_t *access) {
                 u16 ssid = pci_read_word(dev, PCI_SUBSYSTEM_ID);
                 if (ssid == SUBDEVICEID_MESA5I20) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "5I20", 4);
+                    strcpy(board->llio.board_name, "5I20");
                     board->llio.num_ioport_connectors = 3;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P2";
@@ -1053,7 +1053,7 @@ void pci_boards_scan(board_access_t *access) {
                     plx9030_fixup_LASxBRD_READY(&(board->llio));
                 } else if (ssid == SUBDEVICEID_MESA4I65) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "4I65", 4);
+                    strcpy(board->llio.board_name, "4I65");
                     board->llio.num_ioport_connectors = 3;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P1";
@@ -1086,7 +1086,7 @@ void pci_boards_scan(board_access_t *access) {
                 u16 ssid = pci_read_word(dev, PCI_SUBSYSTEM_ID);
                 if ((ssid == SUBDEVICEID_MESA4I68_OLD) || (ssid == SUBDEVICEID_MESA4I68)) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "4I68", 4);
+                    strcpy(board->llio.board_name, "4I68");
                     board->llio.num_ioport_connectors = 3;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P1";
@@ -1114,7 +1114,7 @@ void pci_boards_scan(board_access_t *access) {
                     boards_count++;
                 } else if (ssid == SUBDEVICEID_MESA5I21) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "5I21", 4);
+                    strcpy(board->llio.board_name, "5I21");
                     board->llio.num_ioport_connectors = 2;
                     board->llio.pins_per_connector = 32;
                     board->llio.ioport_connector_name[0] = "P1";
@@ -1141,7 +1141,7 @@ void pci_boards_scan(board_access_t *access) {
                     boards_count++;
                 } else if ((ssid == SUBDEVICEID_MESA5I22_10) || (ssid == SUBDEVICEID_MESA5I22_15)) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "5I22", 4);
+                    strcpy(board->llio.board_name, "5I22");
                     board->llio.num_ioport_connectors = 4;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P2";
@@ -1174,7 +1174,7 @@ void pci_boards_scan(board_access_t *access) {
                     boards_count++;
                 } else if (ssid == SUBDEVICEID_MESA5I23) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "5I23", 4);
+                    strcpy(board->llio.board_name, "5I23");
                     board->llio.num_ioport_connectors = 3;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P2";
@@ -1202,7 +1202,7 @@ void pci_boards_scan(board_access_t *access) {
                     boards_count++;
                 } else if ((ssid == SUBDEVICEID_MESA4I69_16) || (ssid == SUBDEVICEID_MESA4I69_25)) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "4I69", 4);
+                    strcpy(board->llio.board_name, "4I69");
                     board->llio.num_ioport_connectors = 3;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P1";
@@ -1237,7 +1237,7 @@ void pci_boards_scan(board_access_t *access) {
                 u16 ssid = pci_read_word(dev, PCI_SUBSYSTEM_ID);
                 if ((ssid == SUBDEVICEID_MESA3X20_10) || (ssid == SUBDEVICEID_MESA3X20_15) || (ssid == SUBDEVICEID_MESA3X20_20)) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "3X20", 4);
+                    strcpy(board->llio.board_name, "3X20");
                     board->llio.num_ioport_connectors = 6;
                     board->llio.pins_per_connector = 24;
                     board->llio.ioport_connector_name[0] = "P4";
@@ -1278,7 +1278,7 @@ void pci_boards_scan(board_access_t *access) {
                 }
             } else if (dev->device_id == DEVICEID_PLX8112) {
                     board->type = BOARD_PCI;
-                    strncpy(board->llio.board_name, "5I71", 4);
+                    strcpy(board->llio.board_name, "5I71");
                     board->open = &pci_board_open;
                     board->close = &pci_board_close;
                     board->print_info = &pci_print_info;

--- a/spi_boards.c
+++ b/spi_boards.c
@@ -200,7 +200,7 @@ void spi_boards_scan(board_access_t *access) {
         board_t *board = &boards[boards_count];
         board->type = BOARD_SPI;
         strcpy(board->dev_addr, access->dev_addr);
-        strncpy(board->llio.board_name, "7I90", 4);
+        strcpy(board->llio.board_name, "7I90");
         board->llio.num_ioport_connectors = 24;
         board->llio.ioport_connector_name[0] = "P1";
         board->llio.ioport_connector_name[1] = "P2";

--- a/usb_boards.c
+++ b/usb_boards.c
@@ -144,7 +144,7 @@ void usb_boards_scan(board_access_t *access) {
             board->type = BOARD_USB;
             board->mode = BOARD_MODE_FPGA;
             strcpy(board->dev_addr, access->dev_addr);
-            strncpy(board->llio.board_name, "7I43", 4);
+            strcpy(board->llio.board_name, "7I43");
             board->llio.num_ioport_connectors = 2;
             board->llio.pins_per_connector = 24;
             board->llio.ioport_connector_name[0] = "P3";
@@ -185,7 +185,7 @@ void usb_boards_scan(board_access_t *access) {
         board->type = BOARD_USB;
         board->mode = BOARD_MODE_CPLD;
         strcpy(board->dev_addr, access->dev_addr);
-        strncpy(board->llio.board_name, "7I43", 4);
+        strcpy(board->llio.board_name, "7I43");
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 24;
         board->llio.ioport_connector_name[0] = "P3";


### PR DESCRIPTION
Fixes the following warnings:
In function 'strncpy',
    inlined from 'spi_boards_scan' at spi_boards.c:203:9:
/usr/include/bits/string_fortified.h:106:10: warning: '__builtin_strncpy'
output truncated before terminating nul copying 4 bytes
from a string of the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));

In file included from /usr/include/string.h:495,
                 from pci_boards.c:34:
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1281:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1240:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1205:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1177:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1144:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1117:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1089:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1056:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:1026:21:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:995:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:967:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:940:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:912:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:885:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘pci_boards_scan’ at pci_boards.c:851:17:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 14 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In file included from /usr/include/string.h:495,
                 from usb_boards.c:21:
In function ‘strncpy’,
    inlined from ‘usb_boards_scan’ at usb_boards.c:188:9:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘usb_boards_scan’ at usb_boards.c:147:13:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’
output truncated before terminating nul copying 4 bytes from a string of
the same length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:329:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:306:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:283:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:259:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:235:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:211:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:186:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strncpy’,
    inlined from ‘eth_scan_one_addr’ at eth_boards.c:161:13,
    inlined from ‘eth_scan_one_addr.isra.0’ at eth_boards.c:136:12:
/usr/include/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
may be truncated copying 16 bytes from a string of length 19 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>