### PR TITLE
Add sys/io.h stubs implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ ifeq ($(TARGET),linux)
 	CFLAGS += -D_GNU_SOURCE
 endif
 
+ifeq ($(USE_STUBS),1)
+	INCLUDE += -Istubs
+endif
+
 ifeq ($(TARGET),windows)
 	MINGW = c:/MinGW
 	INCLUDE = -I$(MINGW)/include
@@ -51,6 +55,10 @@ CFLAGS += $(OPT) $(DEBUG) $(INCLUDE)
 
 objects = common.o lbp.o lbp16.o bitfile.o hostmot2.o eeprom.o anyio.o eth_boards.o epp_boards.o usb_boards.o pci_boards.o
 objects += sserial_module.o encoder_module.o eeprom_local.o eeprom_remote.o spi_boards.o serial_boards.o
+
+ifeq ($(USE_STUBS),1)
+objects += io.o
+endif
 
 headers = eth_boards.h pci_boards.h epp_boards.h usb_boards.h spi_boards.h serial_boards.h anyio.h hostmot2.h lbp16.h types.h
 headers +=  common.h eeprom.h lbp.h eeprom_local.h eeprom_remote.h bitfile.h sserial_module.h hostmot2_def.h boards.h
@@ -119,6 +127,9 @@ bitfile.o : bitfile.c $(headers)
 
 common.o : common.c $(headers)
 	$(CC) $(CFLAGS) -c common.c
+
+io.o : stubs/sys/io.c stubs/sys/io.h
+	$(CC) $(CFLAGS) -c stubs/sys/io.c
 
 pci_encoder_read.o : examples/pci_encoder_read.c $(LIBANYIO) $(headers)
 	$(CC) $(CFLAGS) -c examples/pci_encoder_read.c

--- a/stubs/sys/io.c
+++ b/stubs/sys/io.c
@@ -1,0 +1,46 @@
+//
+//    Copyright (C) 2020 Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include <errno.h>
+#include "io.h"
+
+unsigned char inb(unsigned short int port) {
+    return 0;
+}
+
+unsigned short int inw(unsigned short int port) {
+    return 0;
+}
+
+unsigned int inl(unsigned short int port) {
+    return 0;
+}
+
+void outb(unsigned char value, unsigned short int port) {
+}
+
+void outw(unsigned short int value, unsigned short int port) {
+}
+
+void outl(unsigned int value, unsigned short int port) {
+}
+
+int iopl(int level) {
+    errno = ENOSYS;
+    return -1;
+}

--- a/stubs/sys/io.h
+++ b/stubs/sys/io.h
@@ -1,0 +1,32 @@
+//
+//    Copyright (C) 2020 Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#ifndef _IO_H_
+#define _IO_H_
+
+unsigned char inb(unsigned short int port);
+unsigned short int inw(unsigned short int port);
+unsigned int inl(unsigned short int port);
+
+void outb(unsigned char value, unsigned short int port);
+void outw(unsigned short int value, unsigned short int port);
+void outl(unsigned int value, unsigned short int port);
+
+int iopl(int level);
+
+#endif


### PR DESCRIPTION
Allows mesaflash to be compiled on platforms (such as arm)
which do not provides <sys/io.h> header file.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>