### PR TITLE
anyio: Add --device AUTO and --device SPI

### DIFF
--- a/anyio.c
+++ b/anyio.c
@@ -31,6 +31,7 @@
 
 supported_board_entry_t supported_boards[] = {
     {"ETHER", BOARD_ETH | BOARD_WILDCARD},
+    {"SPI", BOARD_SPI | BOARD_WILDCARD},
     {"7I92", BOARD_ETH},
     {"7I93", BOARD_ETH},
     {"7I94", BOARD_ETH},
@@ -61,6 +62,7 @@ supported_board_entry_t supported_boards[] = {
     {"7I90", BOARD_MULTI_INTERFACE | BOARD_EPP | BOARD_SPI | BOARD_SER},
     {"7I64", BOARD_MULTI_INTERFACE | BOARD_USB | BOARD_SPI},
 
+    {"AUTO", BOARD_MULTI_INTERFACE | BOARD_WILDCARD | BOARD_USB | BOARD_EPP | BOARD_SPI | BOARD_SER | BOARD_PCI},
     {NULL, 0},
 };
 

--- a/mesaflash.1
+++ b/mesaflash.1
@@ -11,6 +11,10 @@ Read, write, configure Mesa Electronics FPGA cards.
 .BI --device " name"
 Select active device name. If no command is given it will detect board
 with given name and print info about it.
+
+The special values "ETHER", "SPI" and "AUTO" will attempt to detect a device
+on ethernet, SPI, or any interface; --addr still needs to be specified for
+non-PCI devices.
 .TP
 .BI --addr " [ip]|[device]"
 Use ip or device name to look for <name> (IP address for Ethernet boards,


### PR DESCRIPTION
Testing performed:  Both found an attached SPI device on a Pi4 e.g.,
```
$ ./mesaflash --device auto --addr /dev/spidev0.0 --spi --readhmid | head -1
unable to set bpw32, fallback to bpw8
Configuration Name: HOSTMOT2
```