### PR TITLE
Add build-essential to install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Quickstart:
 MesaFlash depends on a couple of packages to build, so install those
 first:
 
-  sudo apt install libpci-dev pkg-config
+  sudo apt install libpci-dev pkg-config build-essential
 
 You may need to install git first:
 


### PR DESCRIPTION
LinuxCNC 2.8.0 Debian .iso (and 2.8.1 update) do not include make.
Adding build-essential to the install list is necessary to make this project.