### PR TITLE
Enable PCI device enumeration on Compute Module 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(TARGET),linux)
     LIBPCI_LDFLAGS := $(shell pkg-config --libs libpci)
     BIN = mesaflash
     LDFLAGS = -lm $(LIBPCI_LDFLAGS)
-    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS)
+    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS) -D_FILE_OFFSET_BITS=64
 
     UNAME_M := $(shell uname -m)
     ifeq ($(UNAME_M),aarch64)

--- a/boards.h
+++ b/boards.h
@@ -60,7 +60,7 @@ struct board_struct {
     struct pci_dev *dev;
     void *base;
     int len;
-    u32 mem_base;
+    int64_t mem_base;
 #ifdef _WIN32
     tagPhysStruct_t mem_handle;
 #endif

--- a/boards.h
+++ b/boards.h
@@ -60,7 +60,7 @@ struct board_struct {
     struct pci_dev *dev;
     void *base;
     int len;
-    int64_t mem_base;
+    u64 mem_base;
 #ifdef _WIN32
     tagPhysStruct_t mem_handle;
 #endif

--- a/pci_boards.c
+++ b/pci_boards.c
@@ -31,8 +31,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include "types.h"
@@ -769,6 +769,10 @@ static int pci_board_open(board_t *board) {
     if (board->mem_base != 0) {
 #ifdef __linux__
         board->base = mmap(0, board->len, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, board->mem_base);
+	if (board->base == NULL || board->base == MAP_FAILED) {
+	    perror("mmap pci");
+	    abort();
+	}
 #elif _WIN32
         board->base = map_memory(board->mem_base, board->len, &(board->mem_handle));
 #endif
@@ -1328,7 +1332,7 @@ void pci_print_info(board_t *board) {
     if (board->data_base_addr > 0)
         printf("  Data I/O addr: %04X\n", board->data_base_addr);
     if (board->mem_base > 0)
-        printf("  Memory: %08X\n", board->mem_base);
+        printf("  Memory: %08" PRIx64 "\n", board->mem_base);
 
     show_board_info(board);
 }

--- a/pci_boards.c
+++ b/pci_boards.c
@@ -1320,7 +1320,7 @@ void pci_print_info(board_t *board) {
                 show_formatted_size(board->dev->size[i]);
                 printf("\n");
             }  else {
-                printf("  Region %d: Memory at %08X", i, (unsigned int) board->dev->base_addr[i]);
+                printf("  Region %d: Memory at %016" PRIx64, i, board->dev->base_addr[i]);
                 show_formatted_size(board->dev->size[i]);
                 printf("\n");
             }
@@ -1332,7 +1332,7 @@ void pci_print_info(board_t *board) {
     if (board->data_base_addr > 0)
         printf("  Data I/O addr: %04X\n", board->data_base_addr);
     if (board->mem_base > 0)
-        printf("  Memory: %08" PRIx64 "\n", board->mem_base);
+        printf("  Memory: %016" PRIx64 "\n", board->mem_base);
 
     show_board_info(board);
 }


### PR DESCRIPTION
 * The PCI offset may be a 64-bit number like 0x600000000, which needs to fit in off_t (for mmap) and board_struct.mem_base
 * off_t is only 64-bits with -D_FILE_OFFSET_BITS=64 (which is not the default in 2021!!!)
 * This requires the offset to be printed as a uint64_t
 * mmap was not checked for failure

After this change, I can detect a 5i24 plugged into the 1x slot of a Raspberry Pi Compute Module 4 IO board with 2GB RAM compute module. That's the only operation I tried.