### PR TITLE
Fix compiler diagnostics etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ RANLIB = ranlib
 OWNERSHIP ?= --owner root --group root
 
 # default CFLAGS
-CFLAGS ?= -O0 -g -Wall -Werror=format -Werror=format-security
+CFLAGS ?= -O0 -g -Wall -Wextra -Werror
 
 # mesaflash needs at least C99 to compile.
 #

--- a/eeprom_remote.c
+++ b/eeprom_remote.c
@@ -36,6 +36,7 @@ extern spi_eeprom_dev_t eeprom_access;
 // eeprom access functions
 
 static void read_page(llio_t *self, u32 addr, void *buff) {
+    (void)self;
     lbp16_cmd_addr_data32 write_addr_pck;
     lbp16_cmd_addr read_page_pck;
 
@@ -48,6 +49,7 @@ static void read_page(llio_t *self, u32 addr, void *buff) {
 }
 
 static void write_page(llio_t *self, u32 addr, void *buff) {
+    (void)self;
     lbp16_cmd_addr_data32 write_addr_pck;
     lbp16_write_flash_page_packets write_page_pck;
     u32 ignored;
@@ -64,6 +66,7 @@ static void write_page(llio_t *self, u32 addr, void *buff) {
 }
 
 static void erase_sector(llio_t *self, u32 addr) {
+    (void)self;
     lbp16_erase_flash_sector_packets sector_erase_pck;
     lbp16_cmd_addr_data32 write_addr_pck;
     u32 ignored;
@@ -93,6 +96,7 @@ int remote_verify_flash(llio_t *self, char *bitfile_name, u32 start_address) {
 }
 
 void open_spi_access_remote(llio_t *self) {
+    (void)self;
     eeprom_access.read_page = &read_page;
     eeprom_access.write_page = &write_page;
     eeprom_access.erase_sector = &erase_sector;
@@ -100,4 +104,5 @@ void open_spi_access_remote(llio_t *self) {
 };
 
 void close_spi_access_remote(llio_t *self) {
+    (void)self;
 };

--- a/eeprom_remote.c
+++ b/eeprom_remote.c
@@ -38,51 +38,44 @@ extern spi_eeprom_dev_t eeprom_access;
 static void read_page(llio_t *self, u32 addr, void *buff) {
     lbp16_cmd_addr_data32 write_addr_pck;
     lbp16_cmd_addr read_page_pck;
-    int send, recv;
 
     LBP16_INIT_PACKET8(write_addr_pck, CMD_WRITE_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, addr);
     LBP16_INIT_PACKET4(read_page_pck, CMD_READ_FPGA_FLASH_ADDR32(64), FLASH_DATA_REG);
 
-    send = lbp16_send_packet(&write_addr_pck, sizeof(write_addr_pck));
-    send = lbp16_send_packet(&read_page_pck, sizeof(read_page_pck));
-    recv = lbp16_recv_packet(buff, PAGE_SIZE);
+    lbp16_send_packet_checked(&write_addr_pck, sizeof(write_addr_pck));
+    lbp16_send_packet_checked(&read_page_pck, sizeof(read_page_pck));
+    lbp16_recv_packet_checked(buff, PAGE_SIZE);
 }
 
 static void write_page(llio_t *self, u32 addr, void *buff) {
     lbp16_cmd_addr_data32 write_addr_pck;
     lbp16_write_flash_page_packets write_page_pck;
-    int send, recv;
     u32 ignored;
 
     LBP16_INIT_PACKET8(write_addr_pck, CMD_WRITE_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, addr);
-    send = lbp16_send_packet(&write_addr_pck, sizeof(write_addr_pck));
+    lbp16_send_packet_checked(&write_addr_pck, sizeof(write_addr_pck));
 
     LBP16_INIT_PACKET6(write_page_pck.write_ena_pck, CMD_WRITE_COMM_CTRL_ADDR16(1), COMM_CTRL_WRITE_ENA_REG, 0x5A03);
     LBP16_INIT_PACKET4(write_page_pck.fl_write_page_pck, CMD_WRITE_FPGA_FLASH_ADDR32(64), FLASH_DATA_REG);
     memcpy(&write_page_pck.fl_write_page_pck.page, buff, 256);
-    send = lbp16_send_packet(&write_page_pck, sizeof(write_page_pck));
+    lbp16_send_packet_checked(&write_page_pck, sizeof(write_page_pck));
     // packet read for board syncing
-    recv = lbp16_read(CMD_READ_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, &ignored, 4);
+    lbp16_read(CMD_READ_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, &ignored, 4);
 }
 
 static void erase_sector(llio_t *self, u32 addr) {
     lbp16_erase_flash_sector_packets sector_erase_pck;
     lbp16_cmd_addr_data32 write_addr_pck;
-    int send, recv;
     u32 ignored;
 
     LBP16_INIT_PACKET8(write_addr_pck, CMD_WRITE_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, addr);
-    send = lbp16_send_packet(&write_addr_pck, sizeof(write_addr_pck));
-    if (send < 0)
-        printf("ERROR: %s(): %s\n", __func__, strerror(errno));
+    lbp16_send_packet_checked(&write_addr_pck, sizeof(write_addr_pck));
 
     LBP16_INIT_PACKET6(sector_erase_pck.write_ena_pck, CMD_WRITE_COMM_CTRL_ADDR16(1), COMM_CTRL_WRITE_ENA_REG, 0x5A03);
     LBP16_INIT_PACKET8(sector_erase_pck.fl_erase_pck, CMD_WRITE_FPGA_FLASH_ADDR32(1), FLASH_SEC_ERASE_REG, 0);
-    send = lbp16_send_packet(&sector_erase_pck, sizeof(sector_erase_pck));
-    if (send < 0)
-        printf("ERROR: %s(): %s\n", __func__, strerror(errno));
+    lbp16_send_packet_checked(&sector_erase_pck, sizeof(sector_erase_pck));
     // packet read for board syncing
-    recv = lbp16_read(CMD_READ_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, &ignored, 4);
+    lbp16_read(CMD_READ_FPGA_FLASH_ADDR32(1), FLASH_ADDR_REG, &ignored, 4);
 }
 
 static int remote_start_programming(llio_t *self, u32 start_address, int fsize) {

--- a/encoder_module.c
+++ b/encoder_module.c
@@ -43,6 +43,7 @@ static void enable_encoder_pins(hostmot2_t *hm2) {
 
 // Return the physical ports to default
 static void disable_encoder_pins(llio_t *llio) {
+    (void)llio;
 }
 
 int encoder_init(encoder_module_t *enc, board_t *board, int instance, int delay) {

--- a/epp_boards.c
+++ b/epp_boards.c
@@ -290,6 +290,7 @@ int epp_reset(llio_t *self) {
 ////////////////////////////////////////////////////////////////////////
 
 int epp_boards_init(board_access_t *access) {
+    (void)access;
 #ifdef __linux__
     if (seteuid(0) != 0) {
         printf("You need root privileges (or setuid root) to access EPP hardware\n");
@@ -302,6 +303,7 @@ int epp_boards_init(board_access_t *access) {
 }
 
 void epp_boards_cleanup(board_access_t *access) {
+    (void)access;
 }
 
 static int epp_board_open(board_t *board) {

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -137,13 +137,13 @@ static int eth_board_close(board_t *board) {
 // Returns 0 if it finds one, -1 if it doesn't find one.
 static int eth_scan_one_addr(board_access_t *access) {
     lbp16_cmd_addr packet, packet2;
-    int send = 0, recv = 0, ret = 0;
+    int ret = 0;
     u32 cookie;
 
     LBP16_INIT_PACKET4(packet, CMD_READ_HM2_COOKIE, HM2_COOKIE_REG);
-    send = lbp16_send_packet(&packet, sizeof(packet));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
     sleep_ns(2*1000*1000);
-    recv = lbp16_recv_packet(&cookie, sizeof(cookie));
+    size_t recv = lbp16_recv_packet(&cookie, sizeof(cookie));
 
     if ((recv > 0) && (cookie == HM2_COOKIE)) {
         char buff[16];
@@ -154,8 +154,8 @@ static int eth_scan_one_addr(board_access_t *access) {
         eth_socket_blocking();
         LBP16_INIT_PACKET4(packet2, CMD_READ_BOARD_INFO_ADDR16_INCR(8), 0);
         memset(buff, 0, sizeof(buff));
-        send = lbp16_send_packet(&packet2, sizeof(packet2));
-        recv = lbp16_recv_packet(&buff, sizeof(buff));
+        lbp16_send_packet_checked(&packet2, sizeof(packet2));
+        lbp16_recv_packet_checked(&buff, sizeof(buff));
 
         if (strncmp(buff, "7I80DB-16", 9) == 0) {
             board->type = BOARD_ETH;
@@ -594,25 +594,25 @@ void eth_print_info(board_t *board) {
 
     LBP16_INIT_PACKET4(packet, CMD_READ_ETH_EEPROM_ADDR16_INCR(sizeof(eth_area)/2), 0);
     memset(&eth_area, 0, sizeof(eth_area));
-    lbp16_send_packet(&packet, sizeof(packet));
-    lbp16_recv_packet(&eth_area, sizeof(eth_area));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(&eth_area, sizeof(eth_area));
 
     LBP16_INIT_PACKET4(packet, CMD_READ_COMM_CTRL_ADDR16_INCR(sizeof(stat_area)/2), 0);
     memset(&stat_area, 0, sizeof(stat_area));
-    lbp16_send_packet(&packet, sizeof(packet));
-    lbp16_recv_packet(&stat_area, sizeof(stat_area));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(&stat_area, sizeof(stat_area));
 
     LBP16_INIT_PACKET4(packet, CMD_READ_BOARD_INFO_ADDR16_INCR(sizeof(info_area)/2), 0);
     memset(&info_area, 0, sizeof(info_area));
-    lbp16_send_packet(&packet, sizeof(packet));
-    lbp16_recv_packet(&info_area, sizeof(info_area));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(&info_area, sizeof(info_area));
 
     if (info_area.LBP16_version >= 3) {
         LBP16_INIT_PACKET4(cmds[4], CMD_READ_AREA_INFO_ADDR16_INCR(LBP16_SPACE_TIMER, sizeof(mem_area)/2), 0);
         LBP16_INIT_PACKET4(packet, CMD_READ_TIMER_ADDR16_INCR(sizeof(timers_area)/2), 0);
         memset(&timers_area, 0, sizeof(timers_area));
-        lbp16_send_packet(&packet, sizeof(packet));
-        lbp16_recv_packet(&timers_area, sizeof(timers_area));
+        lbp16_send_packet_checked(&packet, sizeof(packet));
+        lbp16_recv_packet_checked(&timers_area, sizeof(timers_area));
     }
 
     printf("Communication:\n");
@@ -631,8 +631,8 @@ void eth_print_info(board_t *board) {
 
         if ((cmds[i].cmd_lo == 0) && (cmds[i].cmd_hi == 0)) continue;
         memset(&mem_area, 0, sizeof(mem_area));
-        lbp16_send_packet(&cmds[i], sizeof(cmds[i]));
-        lbp16_recv_packet(&mem_area, sizeof (mem_area));
+        lbp16_send_packet_checked(&cmds[i], sizeof(cmds[i]));
+        lbp16_recv_packet_checked(&mem_area, sizeof (mem_area));
 
         printf("    %d: %.*s (%s, %s", i, (int)sizeof(mem_area.name), mem_area.name, mem_types[(mem_area.size  >> 8) & 0x7F],
           mem_writeable[(mem_area.size & 0x8000) >> 15]);

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -99,6 +99,7 @@ static char *eth_socket_get_src_ip() {
 }
 
 static int eth_read(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     if ((size/4) > LBP16_MAX_PACKET_DATA_SIZE) {
         printf("ERROR: LBP16: Requested %d units to read, but protocol supports up to %d units to be read per packet\n", size/4, LBP16_MAX_PACKET_DATA_SIZE);
         return -1;
@@ -108,6 +109,7 @@ static int eth_read(llio_t *self, u32 addr, void *buffer, int size) {
 }
 
 static int eth_write(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     if ((size/4) > LBP16_MAX_PACKET_DATA_SIZE) {
         printf("ERROR: LBP16: Requested %d units to write, but protocol supports up to %d units to be write per packet\n", size/4, LBP16_MAX_PACKET_DATA_SIZE);
         return -1;
@@ -130,6 +132,7 @@ static int eth_board_open(board_t *board) {
 }
 
 static int eth_board_close(board_t *board) {
+    (void)board;
     return 0;
 }
 
@@ -470,6 +473,7 @@ static int eth_scan_one_addr(board_access_t *access) {
 // public functions
 
 int eth_boards_init(board_access_t *access) {
+    (void)access;
 // open socket
 #ifdef __linux__
     sd = socket (PF_INET, SOCK_DGRAM, 0);
@@ -500,6 +504,7 @@ int eth_boards_init(board_access_t *access) {
 }
 
 void eth_boards_cleanup(board_access_t *access) {
+    (void)access;
     int i;
 
     for (i = 0; i < boards_count; i++) {

--- a/hostmot2.c
+++ b/hostmot2.c
@@ -59,7 +59,7 @@ hm2_module_desc_t *hm2_find_module(hostmot2_t *hm2, u8 gtag) {
     return NULL;
 }
 
-void hm2_set_pin_source(hostmot2_t *hm2, int pin_number, u8 source) {
+void hm2_set_pin_source(hostmot2_t *hm2, u32 pin_number, u8 source) {
     u32 data;
     u16 addr;
     hm2_module_desc_t *md = hm2_find_module(hm2, HM2_GTAG_IOPORT);
@@ -68,7 +68,7 @@ void hm2_set_pin_source(hostmot2_t *hm2, int pin_number, u8 source) {
         printf("hm2_set_pin_source(): no IOPORT module found\n");
         return;
     }
-    if ((pin_number < 0) || (pin_number >= (hm2->idrom.io_ports*hm2->idrom.io_width))) {
+    if (pin_number >= (hm2->idrom.io_ports*hm2->idrom.io_width)) {
         printf("hm2_set_pin_source(): invalid pin number %d\n", pin_number);
         return;
     }
@@ -86,7 +86,7 @@ void hm2_set_pin_source(hostmot2_t *hm2, int pin_number, u8 source) {
     hm2->llio->write(hm2->llio, addr + HM2_MOD_OFFS_GPIO_ALT_SOURCE + (pin_number / 24)*4, &data, sizeof(data));
 }
 
-void hm2_set_pin_direction(hostmot2_t *hm2, int pin_number, u8 direction) {
+void hm2_set_pin_direction(hostmot2_t *hm2, u32 pin_number, u8 direction) {
     u32 data;
     u16 addr;
     hm2_module_desc_t *md = hm2_find_module(hm2, HM2_GTAG_IOPORT);
@@ -95,7 +95,7 @@ void hm2_set_pin_direction(hostmot2_t *hm2, int pin_number, u8 direction) {
         printf("hm2_set_pin_direction(): no IOPORT module found\n");
         return;
     }
-    if ((pin_number < 0) || (pin_number >= (hm2->idrom.io_ports*hm2->idrom.io_width))) {
+    if (pin_number >= (hm2->idrom.io_ports*hm2->idrom.io_width)) {
         printf("hm2_set_pin_direction(): invalid pin number %d\n", pin_number);
         return;
     }

--- a/hostmot2.h
+++ b/hostmot2.h
@@ -91,8 +91,8 @@ void hm2_read_idrom(hostmot2_t *hm2);
 hm2_module_desc_t *hm2_find_module(hostmot2_t *hm2, u8 gtag);
 void hm2_print_pin_file(llio_t *llio, int xml_flag);
 void hm2_print_pin_descriptors(llio_t *llio);
-void hm2_set_pin_source(hostmot2_t *hm2, int pin_number, u8 source);
-void hm2_set_pin_direction(hostmot2_t *hm2, int pin_number, u8 direction);
+void hm2_set_pin_source(hostmot2_t *hm2, u32 pin_number, u8 source);
+void hm2_set_pin_direction(hostmot2_t *hm2, u32 pin_number, u8 direction);
 void sserial_module_init(llio_t *llio);
 
 #endif

--- a/lbp.h
+++ b/lbp.h
@@ -80,8 +80,8 @@ struct lbp_cmd_addr_data_struct {
 } __attribute__ ((__packed__));
 typedef struct lbp_cmd_addr_data_struct lbp_cmd_addr_data;
 
-int lbp_send(void *packet, int size);
-int lbp_recv(void *packet, int size);
+void lbp_send_checked(void *packet, int size);
+void lbp_recv_checked(void *packet, int size);
 u8 lbp_read_ctrl(u8 cmd);
 int lbp_read(u16 addr, void *buffer);
 int lbp_write(u16 addr, void *buffer);

--- a/lbp16.c
+++ b/lbp16.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include "types.h"
 #include "lbp16.h"
 #include "eth_boards.h"
@@ -26,27 +27,38 @@
 
 static lbp16_access_t lbp16_access;
 
-int lbp16_send_packet(void *packet, int size) {
-    return lbp16_access.send_packet(packet, size);
+void lbp16_send_packet_checked(void *packet, int size) {
+    int result = lbp16_access.send_packet(packet, size);
+    if (size != result) {
+        perror("lbp16_access.send_packet");
+        abort();
+    }
 }
 
 int lbp16_recv_packet(void *packet, int size) {
     return lbp16_access.recv_packet(packet, size);
 }
 
+void lbp16_recv_packet_checked(void *packet, int size) {
+    int result = lbp16_access.recv_packet(packet, size);
+    if (size != result) {
+        perror("lbp16_access.recv_packet");
+        abort();
+    }
+}
+
 int lbp16_read(u16 cmd, u32 addr, void *buffer, int size) {
     lbp16_cmd_addr packet;
-    int send, recv;
     u8 local_buff[size];
 
     LBP16_INIT_PACKET4(packet, cmd, addr);
     if (LBP16_SENDRECV_DEBUG) {
         printf("SEND: %02X %02X %02X %02X | REQUEST %d bytes\n", packet.cmd_hi, packet.cmd_lo, packet.addr_hi, packet.addr_lo, size);
     }
-    send = lbp16_access.send_packet(&packet, sizeof(packet));
-    recv = lbp16_access.recv_packet(&local_buff, sizeof(local_buff));
+    lbp16_access.send_packet(&packet, sizeof(packet));
+    lbp16_access.recv_packet(&local_buff, sizeof(local_buff));
     if (LBP16_SENDRECV_DEBUG) {
-        printf("RECV: %d bytes\n", recv);
+        printf("RECV: %zd bytes\n", sizeof(local_buff));
     }
     memcpy(buffer, local_buff, size);
 
@@ -58,7 +70,6 @@ int lbp16_write(u16 cmd, u32 addr, void *buffer, int size) {
         lbp16_cmd_addr wr_packet;
         u8 tmp_buffer[LBP16_MAX_PACKET_DATA_SIZE*8];
     } packet;
-    int send;
 
     LBP16_INIT_PACKET4(packet.wr_packet, cmd, addr);
     memcpy(&packet.tmp_buffer, buffer, size);
@@ -66,32 +77,30 @@ int lbp16_write(u16 cmd, u32 addr, void *buffer, int size) {
         printf("SEND: %02X %02X %02X %02X | WRITE %d bytes\n", packet.wr_packet.cmd_hi, packet.wr_packet.cmd_lo,
           packet.wr_packet.addr_hi, packet.wr_packet.addr_lo, size);
     }
-    send = lbp16_access.send_packet(&packet, sizeof(lbp16_cmd_addr) + size);
+    lbp16_access.send_packet(&packet, sizeof(lbp16_cmd_addr) + size);
 
     return 0;
 }
 
 int lbp16_board_reset(llio_t *self) {
-    int send;
     lbp16_cmd_addr_data16 packet;
 
     LBP16_INIT_PACKET6(packet, CMD_WRITE_COMM_CTRL_ADDR16(1), 0x1C, 0x0001);   // reset if != 0
-    send = lbp16_send_packet(&packet, sizeof(packet));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
 
     return 0;
 }
 
 int lbp16_board_reload(llio_t *self, int fallback_flag) {
     board_t *board = self->board;
-    int send;
     u32 boot_addr;
     u16 fw_ver;
     lbp16_cmd_addr_data16 packet[14];
     lbp16_cmd_addr fw_packet;
 
     LBP16_INIT_PACKET4(fw_packet, CMD_READ_BOARD_INFO_ADDR16(1), offsetof(lbp_info_area, firmware_version));
-    lbp16_send_packet(&fw_packet, sizeof(fw_packet));
-    lbp16_recv_packet(&fw_ver, sizeof(fw_ver));
+    lbp16_send_packet_checked(&fw_packet, sizeof(fw_packet));
+    lbp16_recv_packet_checked(&fw_ver, sizeof(fw_ver));
 
     if ((board->type & BOARD_ETH) && (fw_ver < 15)) {
         printf("ERROR: FPGA reload only supported by ethernet card firmware > 14.\n");
@@ -122,7 +131,7 @@ int lbp16_board_reload(llio_t *self, int fallback_flag) {
     LBP16_INIT_PACKET6(packet[11], CMD_WRITE_COMM_CTRL_ADDR16(1), 0x1E, 0x2000);  // NOP
     LBP16_INIT_PACKET6(packet[12], CMD_WRITE_COMM_CTRL_ADDR16(1), 0x1E, 0x2000);  // NOP
     LBP16_INIT_PACKET6(packet[13], CMD_WRITE_COMM_CTRL_ADDR16(1), 0x1E, 0x2000);  // NOP
-    send = lbp16_send_packet(&packet, sizeof(packet));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
 
     return 0;
 }

--- a/lbp16.c
+++ b/lbp16.c
@@ -83,6 +83,7 @@ int lbp16_write(u16 cmd, u32 addr, void *buffer, int size) {
 }
 
 int lbp16_board_reset(llio_t *self) {
+    (void)self;
     lbp16_cmd_addr_data16 packet;
 
     LBP16_INIT_PACKET6(packet, CMD_WRITE_COMM_CTRL_ADDR16(1), 0x1C, 0x0001);   // reset if != 0
@@ -152,4 +153,5 @@ void lbp16_init(int board_type) {
 }
 
 void lbp_cleanup(int board_type) {
+    (void)board_type;
 }

--- a/lbp16.h
+++ b/lbp16.h
@@ -256,7 +256,8 @@ int lbp16_read(u16 cmd, u32 addr, void *buffer, int size);
 int lbp16_write(u16 cmd, u32 addr, void *buffer, int size);
 int lbp16_board_reset(llio_t *self);
 int lbp16_board_reload(llio_t *self, int fallback_flag);
-int lbp16_send_packet(void *packet, int size);
+void lbp16_send_packet_checked(void *packet, int size);
 int lbp16_recv_packet(void *packet, int size);
+void lbp16_recv_packet_checked(void *packet, int size);
 
 #endif

--- a/pci_boards.c
+++ b/pci_boards.c
@@ -762,6 +762,8 @@ static void pci_fix_bar_lengths(struct pci_dev *dev) {
 
         dev->size[i] = size + 1;
     }
+#else
+    (void)dev;
 #endif
 }
 
@@ -805,6 +807,7 @@ static int pci_board_close(board_t *board) {
 }
 
 int pci_boards_init(board_access_t *access) {
+    (void)access;
     int eno;
 
 #ifdef __linux__
@@ -833,6 +836,7 @@ int pci_boards_init(board_access_t *access) {
 }
 
 void pci_boards_cleanup(board_access_t *access) {
+    (void)access;
 #ifdef __linux__
     close(memfd);
 #elif _WIN32

--- a/serial_boards.c
+++ b/serial_boards.c
@@ -173,12 +173,11 @@ void serial_boards_cleanup(board_access_t *access) {
 
 void serial_boards_scan(board_access_t *access) {
     lbp16_cmd_addr packet;
-    int send = 0, recv = 0;
     char buff[16];
 
     LBP16_INIT_PACKET4(packet, CMD_READ_BOARD_INFO_ADDR16_INCR(8), 0);
-    send = lbp16_send_packet(&packet, sizeof(packet));
-    recv = lbp16_recv_packet(buff, 16);
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(buff, 16);
     if (strncmp(buff, "7I90HD", 6) == 0) {
         board_t *board = &boards[boards_count];
 
@@ -214,7 +213,7 @@ void serial_boards_scan(board_access_t *access) {
 
 void serial_print_info(board_t *board) {
     lbp16_cmd_addr packet;
-    int i, j, recv;
+    int i, j;
     char *mem_types[16] = {NULL, "registers", "memory", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, "EEPROM", "flash"};
     char *mem_writeable[2] = {"RO", "RW"};
     char *acc_types[4] = {"8-bit", "16-bit", "32-bit", "64-bit"};
@@ -239,20 +238,20 @@ void serial_print_info(board_t *board) {
 
     LBP16_INIT_PACKET4(packet, CMD_READ_COMM_CTRL_ADDR16_INCR(sizeof(stat_area)/2), 0);
     memset(&stat_area, 0, sizeof(stat_area));
-    lbp16_send_packet(&packet, sizeof(packet));
-    recv = lbp16_recv_packet(&stat_area, sizeof(stat_area));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(&stat_area, sizeof(stat_area));
 
     LBP16_INIT_PACKET4(packet, CMD_READ_BOARD_INFO_ADDR16_INCR(sizeof(info_area)/2), 0);
     memset(&info_area, 0, sizeof(info_area));
-    lbp16_send_packet(&packet, sizeof(packet));
-    recv = lbp16_recv_packet(&info_area, sizeof(info_area));
+    lbp16_send_packet_checked(&packet, sizeof(packet));
+    lbp16_recv_packet_checked(&info_area, sizeof(info_area));
 
     if (info_area.LBP16_version >= 3) {
         LBP16_INIT_PACKET4(cmds[4], CMD_READ_AREA_INFO_ADDR16_INCR(LBP16_SPACE_TIMER, sizeof(mem_area)/2), 0);
         LBP16_INIT_PACKET4(packet, CMD_READ_TIMER_ADDR16_INCR(sizeof(timers_area)/2), 0);
         memset(&timers_area, 0, sizeof(timers_area));
-        lbp16_send_packet(&packet, sizeof(packet));
-        recv = lbp16_recv_packet(&timers_area, sizeof(timers_area));
+        lbp16_send_packet_checked(&packet, sizeof(packet));
+        lbp16_recv_packet_checked(&timers_area, sizeof(timers_area));
     }
 
     printf("Communication:\n");
@@ -268,8 +267,8 @@ void serial_print_info(board_t *board) {
 
         if ((cmds[i].cmd_lo == 0) && (cmds[i].cmd_hi == 0)) continue;
         memset(&mem_area, 0, sizeof(mem_area));
-        lbp16_send_packet(&cmds[i], sizeof(cmds[i]));
-        lbp16_recv_packet(&mem_area, sizeof (mem_area));
+        lbp16_send_packet_checked(&cmds[i], sizeof(cmds[i]));
+        lbp16_recv_packet_checked(&mem_area, sizeof (mem_area));
 
         printf("    %d: %.*s (%s, %s", i, (int)sizeof(mem_area.name), mem_area.name, mem_types[(mem_area.size  >> 8) & 0x7F],
           mem_writeable[(mem_area.size & 0x8000) >> 15]);

--- a/serial_boards.c
+++ b/serial_boards.c
@@ -102,10 +102,12 @@ int serial_recv_packet(void *packet, int size) {
 }
 
 static int serial_read(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     return lbp16_read(CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr, buffer, size);
 }
 
 static int serial_write(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     return lbp16_write(CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr, buffer, size);
 }
 
@@ -122,6 +124,7 @@ static int serial_board_open(board_t *board) {
 }
 
 static int serial_board_close(board_t *board) {
+    (void)board;
     return 0;
 }
 
@@ -168,6 +171,7 @@ int serial_boards_init(board_access_t *access) {
 }
 
 void serial_boards_cleanup(board_access_t *access) {
+    (void)access;
     close(sd);
 }
 

--- a/spi_boards.c
+++ b/spi_boards.c
@@ -326,8 +326,7 @@ void spi_boards_scan(board_access_t *access) {
         board->fallback_support = 1;
         boards_count ++; 
      } else {
-        int i=0;
-        for(i=0; i<sizeof(ident); i++)
+        for(size_t i=0; i<sizeof(ident); i++)
             if(!isprint(ident[i])) ident[i] = '?';
 
         fprintf(stderr, "Unknown board: %.8s\n", ident);

--- a/spi_boards.c
+++ b/spi_boards.c
@@ -83,6 +83,7 @@ static int spi_board_open(board_t *board) {
 }
 
 static int spi_board_close(board_t *board) {
+    (void)board;
     return 0;
 }
 
@@ -110,6 +111,7 @@ int spi_boards_init(board_access_t *access) {
 }
 
 void spi_boards_cleanup(board_access_t *access) {
+    (void)access;
     if(sd != -1) close(sd);
 }
 
@@ -129,6 +131,7 @@ void reorderBuffer(char *pBuf, int numInts)
 }
 
 int spi_read(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     if(size % 4 != 0) return -1;
     int numInts = 1+size/4;
     u32 trxbuf[numInts];
@@ -158,6 +161,7 @@ int spi_read(llio_t *self, u32 addr, void *buffer, int size) {
 }
 
 int spi_write(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     if(size % 4 != 0) return -1;
     int numInts = 1+size/4;
     u32 txbuf[numInts];
@@ -331,4 +335,5 @@ void spi_boards_scan(board_access_t *access) {
 }
 
 void spi_print_info(board_t *board) {
+    (void)board;
 }

--- a/sserial_module.c
+++ b/sserial_module.c
@@ -26,9 +26,9 @@
 
 // Temporarily enable the pins that are not masked by sserial_mode
 static void enable_sserial_pins(llio_t *llio) {
-    int port_pin, port;
-    int pin = -1;
-    int chan_counts[] = {0,0,0,0,0,0,0,0};
+    u32 port_pin, port;
+    u32 pin = -1;
+    u16 chan_counts[] = {0,0,0,0,0,0,0,0};
     hm2_module_desc_t *md = hm2_find_module(&(llio->hm2), HM2_GTAG_IOPORT);
     u16 addr = md->base_address;
 

--- a/sserial_module.h
+++ b/sserial_module.h
@@ -32,7 +32,7 @@ struct opd_mode_1_7i77_struct {
     unsigned int analogena : 1;
     unsigned int spinena   : 1;
     unsigned int ignore1   : 16;
-} __attribute__ ((__packed__));
+} __attribute__ ((__packed__, aligned(4)));
 
 typedef struct opd_mode_1_7i77_struct opd_mode_1_7i77_t;
 

--- a/usb_boards.c
+++ b/usb_boards.c
@@ -79,10 +79,10 @@ static int usb_program_fpga(llio_t *self, char *bitfile_name) {
     printf("  |");
     fflush(stdout);
     
-    lbp_send(&cmd, 1);
-    lbp_send(&cmd, 1);
-    lbp_send(&cmd, 1);
-    lbp_send(&cmd, 1);
+    lbp_send_checked(&cmd, 1);
+    lbp_send_checked(&cmd, 1);
+    lbp_send_checked(&cmd, 1);
+    lbp_send_checked(&cmd, 1);
     // program the FPGA
     while (!feof(fp)) {
         bytesread = fread(&file_buffer, 1, 8192, fp);
@@ -91,7 +91,7 @@ static int usb_program_fpga(llio_t *self, char *bitfile_name) {
             file_buffer[bindex] = bitfile_reverse_bits(file_buffer[bindex]);
             bindex++;
         }
-        lbp_send(&file_buffer, bytesread);
+        lbp_send_checked(&file_buffer, bytesread);
         printf("W");
         fflush(stdout);
     }
@@ -179,8 +179,8 @@ void usb_boards_scan(board_access_t *access) {
     }
 
     cmd = '1';
-    lbp_send(&cmd, 1);
-    lbp_recv(&data, 1);
+    lbp_send_checked(&cmd, 1);
+    lbp_recv_checked(&data, 1);
     if ((data & 0x01) == 0) {  // found 7i43 without flashed FPGA
         board->type = BOARD_USB;
         board->mode = BOARD_MODE_CPLD;
@@ -191,8 +191,8 @@ void usb_boards_scan(board_access_t *access) {
         board->llio.ioport_connector_name[0] = "P3";
         board->llio.ioport_connector_name[1] = "P4";
         cmd = '0';
-        lbp_send(&cmd, 1);
-        lbp_recv(&data, 1);
+        lbp_send_checked(&cmd, 1);
+        lbp_recv_checked(&data, 1);
         if (data & 0x01)
             board->llio.fpga_part_number = "3s400tq144";
         else

--- a/usb_boards.c
+++ b/usb_boards.c
@@ -34,6 +34,7 @@ extern int boards_count;
 static u8 file_buffer[SECTOR_SIZE];
 
 int usb_read(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     while (size > 0) {
         lbp_read(addr & 0xFFFF, buffer);
         addr += 4;
@@ -44,6 +45,7 @@ int usb_read(llio_t *self, u32 addr, void *buffer, int size) {
 }
 
 int usb_write(llio_t *self, u32 addr, void *buffer, int size) {
+    (void)self;
     while (size > 0) {
         lbp_write(addr & 0xFFFF, buffer);
         addr += 4;
@@ -103,10 +105,12 @@ static int usb_program_fpga(llio_t *self, char *bitfile_name) {
 }
 
 static int usb_board_open(board_t *board) {
+    (void)board;
     return 0;
 }
 
 static int usb_board_close(board_t *board) {
+    (void)board;
     return 0;
 }
 
@@ -116,6 +120,7 @@ int usb_boards_init(board_access_t *access) {
 }
 
 void usb_boards_cleanup(board_access_t *access) {
+    (void)access;
     lbp_release();
 }
 
@@ -210,6 +215,7 @@ void usb_boards_scan(board_access_t *access) {
 }
 
 void usb_boards_release(board_access_t *access) {
+    (void)access;
     lbp_release();
 }
 


### PR DESCRIPTION
This fixes several classes of compiler diagnostics, so that the software now builds clean with `-Wall -Wextra -Werror` on Debian Buster.  This was only compile-tested however, not run on hardware.