### PR TITLE
no need to override dh_clean

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,3 @@ get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz
 
 $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.xz:
 	git archive HEAD | xz --compress > $@
-
-override_dh_clean:
-	rm -rf winio32 WinIo32.* libpci.dll libpci
-	dh_clean


### PR DESCRIPTION
This was used to remove non-source files that were used by the Windows build of mesaflash.  These files were removed from git, so there's no need to handle them specially when running `debian/rules clean`.