### PR TITLE
fix d/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,11 +4,21 @@ Upstream-Contact: LinuxCNC Developers <emc-developers@lists.sourceforge.net>
 Source: https://github.com/micges/mesaflash
 
 Files: *
-Copyright: 2013-2014 Michael Geszkiewicz
+Copyright: 2013-2015 Michael Geszkiewicz
+Copyright: 2014, 2016, 2020, 2021 Jeff Epler
+Copyright: 2015 Joe Calderon
+Copyright: 2017, 2020 Sebastian Kuzminsky
+Copyright: 2019-2021 Peter Wallace
+Copyright: 2020 Damian Wrobel
+Copyright: 2020 Curtis Dutton
+
 License: GPL-2.0+
 
 Files: debian/*
-Copyright: #YEAR# #USERNAME# <#EMAIL#>
+Copyright: 2015 Chris Radek
+Copyright: 2016, 2021 Jeff Epler
+Copyright: 2014-2021 Sebastian Kuzminsky
+Copyright: 2021 Steffen Moeller
 License: GPL-2.0+
 
 License: GPL-2.0+


### PR DESCRIPTION
Flesh out copyright, based on feedback from the Debian FTP Masters.