### PR TITLE
debian/copyright: avoiding extra "Copyright:"s

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,20 +5,19 @@ Source: https://github.com/micges/mesaflash
 
 Files: *
 Copyright: 2013-2015 Michael Geszkiewicz
-Copyright: 2014, 2016, 2020, 2021 Jeff Epler
-Copyright: 2015 Joe Calderon
-Copyright: 2017, 2020 Sebastian Kuzminsky
-Copyright: 2019-2021 Peter Wallace
-Copyright: 2020 Damian Wrobel
-Copyright: 2020 Curtis Dutton
-
+           2014, 2016, 2020-2021 Jeff Epler
+           2015 Joe Calderon
+           2017, 2020 Sebastian Kuzminsky
+           2019-2021 Peter Wallace
+           2020 Damian Wrobel
+           2020 Curtis Dutton
 License: GPL-2.0+
 
 Files: debian/*
 Copyright: 2015 Chris Radek
-Copyright: 2016, 2021 Jeff Epler
-Copyright: 2014-2021 Sebastian Kuzminsky
-Copyright: 2021 Steffen Moeller
+           2016, 2021 Jeff Epler
+           2014-2021 Sebastian Kuzminsky
+           2021 Steffen Moeller
 License: GPL-2.0+
 
 License: GPL-2.0+


### PR DESCRIPTION
Hi @SebKuzminsky , Thank you for addressing this. Did a few changes as already described in my PM, changed my opinion on the debian/* entry since Chris is not listed as a regular author, so I can appear in the Files: debian/* section, too.