### PR TITLE
Add --backup-flash and --restore-flash commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,18 @@ ifeq ($(TARGET),linux)
         $(error "pkg-config can't find libpci")
     endif
 
+    $(shell pkg-config --exists libcrypto > /dev/null)
+    ifeq ($(.SHELLSTATUS), 1)
+        $(error "pkg-config can't find libcrypto")
+    endif
+
     LIBPCI_CFLAGS := $(shell pkg-config --cflags libpci)
     LIBPCI_LDFLAGS := $(shell pkg-config --libs libpci)
+    LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto)
+    LIBCRYPTO_LDFLAGS := $(shell pkg-config --libs libcrypto)
     BIN = mesaflash
-    LDFLAGS = -lm $(LIBPCI_LDFLAGS)
-    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS) -D_FILE_OFFSET_BITS=64
+    LDFLAGS = -lm $(LIBPCI_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
+    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS) $(LIBCRYPTO_CFLAGS) -D_FILE_OFFSET_BITS=64
 
     UNAME_M := $(shell uname -m)
     ifeq ($(UNAME_M),aarch64)

--- a/anyio.c
+++ b/anyio.c
@@ -284,6 +284,21 @@ int anyio_dev_backup_flash(board_t *board, char *bitfile_name) {
     return ret;
 }
 
+int anyio_dev_restore_flash(board_t *board, char *bitfile_name) {
+    int ret;
+
+    if (board == NULL) {
+        return -EINVAL;
+    }
+    if (board->llio.restore_flash != NULL) {
+        ret = board->llio.restore_flash(&(board->llio), bitfile_name);
+    } else {
+        printf("ERROR: Board %s doesn't support restore flash.\n", board->llio.board_name);
+        return -EINVAL;
+    }
+    return ret;
+}
+
 int anyio_dev_program_fpga(board_t *board, char *bitfile_name) {
     int ret;
 

--- a/anyio.c
+++ b/anyio.c
@@ -269,6 +269,21 @@ int anyio_dev_verify_flash(board_t *board, char *bitfile_name, int fallback_flag
     return ret;
 }
 
+int anyio_dev_backup_flash(board_t *board, char *bitfile_name) {
+    int ret;
+
+    if (board == NULL) {
+        return -EINVAL;
+    }
+    if (board->llio.backup_flash != NULL) {
+        ret = board->llio.backup_flash(&(board->llio), bitfile_name);
+    } else {
+        printf("ERROR: Board %s doesn't support backup flash.\n", board->llio.board_name);
+        return -EINVAL;
+    }
+    return ret;
+}
+
 int anyio_dev_program_fpga(board_t *board, char *bitfile_name) {
     int ret;
 

--- a/anyio.h
+++ b/anyio.h
@@ -32,6 +32,7 @@ board_t *anyio_get_dev(board_access_t *access, int board_number);
 int anyio_dev_write_flash(board_t *board, char *bitfile_name, int fallback_flag, int fix_boot_flag);
 int anyio_dev_verify_flash(board_t *board, char *bitfile_name, int fallback_flag);
 int anyio_dev_backup_flash(board_t *board, char *bitfile_name);
+int anyio_dev_restore_flash(board_t *board, char *bitfile_name);
 int anyio_dev_program_fpga(board_t *board, char *bitfile_name);
 int anyio_dev_set_remote_ip(board_t *board, char *lbp16_set_ip_addr);
 int anyio_dev_reload(board_t *board, int fallback_flag);

--- a/anyio.h
+++ b/anyio.h
@@ -31,6 +31,7 @@ int anyio_find_dev(board_access_t *access);
 board_t *anyio_get_dev(board_access_t *access, int board_number);
 int anyio_dev_write_flash(board_t *board, char *bitfile_name, int fallback_flag, int fix_boot_flag);
 int anyio_dev_verify_flash(board_t *board, char *bitfile_name, int fallback_flag);
+int anyio_dev_backup_flash(board_t *board, char *bitfile_name);
 int anyio_dev_program_fpga(board_t *board, char *bitfile_name);
 int anyio_dev_set_remote_ip(board_t *board, char *lbp16_set_ip_addr);
 int anyio_dev_reload(board_t *board, int fallback_flag);

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Priority: optional
 Standards-Version: 3.9.4
 Build-Depends: debhelper (>= 9),
                libpci-dev,
-               libcrypto-dev,
+               libssl-dev,
                pkg-config
 Vcs-Browser: https://github.com/linuxcnc/mesaflash
 Vcs-git: https://github.com/LinuxCNC/mesaflash.git -b master

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Priority: optional
 Standards-Version: 3.9.4
 Build-Depends: debhelper (>= 9),
                libpci-dev,
+               libcrypto-dev,
                pkg-config
 Vcs-Browser: https://github.com/linuxcnc/mesaflash
 Vcs-git: https://github.com/LinuxCNC/mesaflash.git -b master

--- a/eeprom.c
+++ b/eeprom.c
@@ -244,7 +244,7 @@ int eeprom_write(llio_t *self, char *bitfile_name, u32 start_address, int fix_bo
 int eeprom_verify(llio_t *self, char *bitfile_name, u32 start_address) {
     board_t *board = self->board;
     int bytesread, i, bindex, all_flash;
-    u32 eeprom_addr;//, eeprom_size;
+    u32 eeprom_addr;
     char part_name[32];
     struct stat file_stat;
     FILE *fp;
@@ -261,7 +261,6 @@ int eeprom_verify(llio_t *self, char *bitfile_name, u32 start_address) {
         return -1;
     }
 
-    //eeprom_size = eeprom_get_flash_size(board->flash_id);
     if (file_stat.st_size != eeprom_get_flash_size(board->flash_id)) {
         if (print_bitfile_header(fp, (char*) &part_name, board->llio.verbose) == -1) {
             fclose(fp);
@@ -285,7 +284,6 @@ int eeprom_verify(llio_t *self, char *bitfile_name, u32 start_address) {
             }
         }
     } else {
-        //printf("Verify all FLASH memory:\n");
         start_address = 0;
         all_flash = 1;
     }
@@ -339,7 +337,7 @@ int flash_backup(llio_t *self, char *bitfile_name) {
     SHA256_CTX sha256ctx;
     unsigned char sha256out[32];
     char sha256str[65];
-    char sha256file_name[255];
+    char sha256file_name[262];
 
     if (eeprom_get_flash_size(board->flash_id) == 0) {
         printf("Unknown size FLASH memory on the %s board\n", board->llio.board_name);
@@ -357,7 +355,7 @@ int flash_backup(llio_t *self, char *bitfile_name) {
 
     fp = fopen(bitfile_name, "wb");
     if (fp == NULL) {
-        printf("Can't open file %s: %s\n", bitfile_name, strerror(errno));
+        printf("Can't create file '%s': %s\n", bitfile_name, strerror(errno));
         return -1;
     }
 
@@ -404,7 +402,7 @@ int flash_backup(llio_t *self, char *bitfile_name) {
     strcat(sha256file_name, ".sha256");
     fp = fopen(sha256file_name, "wb");
     if (fp == NULL) {
-        printf("Can't open file '%s': %s\n", sha256file_name, strerror(errno));
+        printf("Can't create file '%s': %s\n", sha256file_name, strerror(errno));
         return -1;
     }
     fprintf(fp, "%s %8d %s", sha256str, eeprom_get_flash_size(board->flash_id), bitfile_name);
@@ -450,7 +448,7 @@ int flash_restore(llio_t *self, char *bitfile_name) {
     FILE *fp;
     struct timeval tv1, tv2;
     char sha256str[65];
-    char sha256file_name[255];
+    char sha256file_name[262];
     unsigned char sha256in[32];
     unsigned char sha256bitfile[32];
     SHA256_CTX sha256ctx;
@@ -572,7 +570,7 @@ int flash_restore(llio_t *self, char *bitfile_name) {
         printf("  Programming time: %.2f seconds\n", (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
          (double) (tv2.tv_sec - tv1.tv_sec));
     }
-    printf("Board FLASH memory restored successfully.\n");
+    printf("Board FLASH memory writed successfully.\n");
     return 0;
 }
 

--- a/eeprom.c
+++ b/eeprom.c
@@ -333,11 +333,12 @@ int flash_backup(llio_t *self, char *bitfile_name) {
     struct timeval tv1, tv2;
     time_t now = time(NULL);
     struct tm *t = localtime(&now);
-    char tmp_name[50];
+    char auto_name[33];
+    char bitfile_path[300];
     SHA256_CTX sha256ctx;
     unsigned char sha256out[32];
     char sha256str[65];
-    char sha256file_name[262];
+    char sha256file_path[307];
 
     if (eeprom_get_flash_size(board->flash_id) == 0) {
         printf("Unknown size FLASH memory on the %s board\n", board->llio.board_name);
@@ -346,16 +347,17 @@ int flash_backup(llio_t *self, char *bitfile_name) {
 
     printf("\nCreating backup %s FLASH memory on the %s board:\n", eeprom_get_flash_type(board->flash_id), board->llio.board_name);
 
-    if (strcasecmp(bitfile_name,"auto") == 0) {
-        strcpy(bitfile_name, board->llio.board_name);
-        strftime(tmp_name, sizeof(tmp_name)-1, "_flash_backup_%d%m%y_%H%M%S.bin", t);
-        strcat(bitfile_name, tmp_name);
-        printf("Used auto naming backup file: '%s'\n", bitfile_name);
+    strcpy(bitfile_path, bitfile_name);
+    if (bitfile_name[strlen(bitfile_name)-1] == '/') {
+        strcat(bitfile_path, board->llio.board_name);
+        strftime(auto_name, sizeof(auto_name)-1, "_flash_backup_%d%m%y_%H%M%S.bin", t);
+        strcat(bitfile_path, auto_name);
+        printf("Used auto naming backup file: '%s%s'\n", board->llio.board_name, auto_name);
     }
 
-    fp = fopen(bitfile_name, "wb");
+    fp = fopen(bitfile_path, "wb");
     if (fp == NULL) {
-        printf("Can't create file '%s': %s\n", bitfile_name, strerror(errno));
+        printf("Can't create file '%s': %s\n", bitfile_path, strerror(errno));
         return -1;
     }
 
@@ -396,18 +398,18 @@ int flash_backup(llio_t *self, char *bitfile_name) {
         printf("  Backup time: %.2f seconds\n", (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
          (double) (tv2.tv_sec - tv1.tv_sec));
     }
-    printf("FLASH memory backup file '%s' created successfully.\n", bitfile_name);
+    printf("FLASH memory backup file '%s' created successfully.\n", bitfile_path);
 
-    strcpy(sha256file_name, bitfile_name);
-    strcat(sha256file_name, ".sha256");
-    fp = fopen(sha256file_name, "wb");
+    strcpy(sha256file_path, bitfile_path);
+    strcat(sha256file_path, ".sha256");
+    fp = fopen(sha256file_path, "wb");
     if (fp == NULL) {
-        printf("Can't create file '%s': %s\n", sha256file_name, strerror(errno));
+        printf("Can't create file '%s': %s\n", sha256file_path, strerror(errno));
         return -1;
     }
-    fprintf(fp, "%s %8d %s", sha256str, eeprom_get_flash_size(board->flash_id), bitfile_name);
+    fprintf(fp, "%s %8d %s", sha256str, eeprom_get_flash_size(board->flash_id), bitfile_path);
     fclose(fp);
-    printf("Checksum file '%s' created successfully,\n", sha256file_name);
+    printf("Checksum file '%s' created successfully,\n", sha256file_path);
     printf("sha256: '%s'\n", sha256str);
     return 0;
 }

--- a/eeprom.h
+++ b/eeprom.h
@@ -58,6 +58,8 @@ int start_programming(llio_t *self, u32 start_address, int fsize);
 int eeprom_write(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int eeprom_verify(llio_t *self, char *bitfile_name, u32 start_address);
 int flash_backup(llio_t *self, char *bitfile_name);
+int flash_erase(llio_t *self);
+int flash_restore(llio_t *self, char *bitfile_name);
 void eeprom_init(llio_t *self);
 void eeprom_cleanup(llio_t *self);
 

--- a/eeprom.h
+++ b/eeprom.h
@@ -57,6 +57,7 @@ void eeprom_prepare_boot_block(u8 flash_id);
 int start_programming(llio_t *self, u32 start_address, int fsize);
 int eeprom_write(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int eeprom_verify(llio_t *self, char *bitfile_name, u32 start_address);
+int flash_backup(llio_t *self, char *bitfile_name);
 void eeprom_init(llio_t *self);
 void eeprom_cleanup(llio_t *self);
 

--- a/eeprom_local.c
+++ b/eeprom_local.c
@@ -428,6 +428,10 @@ int local_backup_flash(llio_t *self, char *bitfile_name) {
     return flash_backup(self, bitfile_name);
 }
 
+int local_restore_flash(llio_t *self, char *bitfile_name) {
+    return flash_restore(self, bitfile_name);
+}
+
 void open_spi_access_local(llio_t *self) {
     board_t *board = self->board;
 

--- a/eeprom_local.c
+++ b/eeprom_local.c
@@ -424,6 +424,10 @@ int local_verify_flash(llio_t *self, char *bitfile_name, u32 start_address) {
     return eeprom_verify(self, bitfile_name, start_address);
 }
 
+int local_backup_flash(llio_t *self, char *bitfile_name) {
+    return flash_backup(self, bitfile_name);
+}
+
 void open_spi_access_local(llio_t *self) {
     board_t *board = self->board;
 

--- a/eeprom_local.h
+++ b/eeprom_local.h
@@ -47,6 +47,7 @@ u8 read_flash_id(llio_t *self);
 int local_write_flash(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int local_verify_flash(llio_t *self, char *bitfile_name, u32 start_address);
 int local_backup_flash(llio_t *self, char *bitfile_name);
+int local_restore_flash(llio_t *self, char *bitfile_name);
 void open_spi_access_local(llio_t *self);
 void close_spi_access_local(llio_t *self);
 

--- a/eeprom_local.h
+++ b/eeprom_local.h
@@ -46,6 +46,7 @@
 u8 read_flash_id(llio_t *self);
 int local_write_flash(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int local_verify_flash(llio_t *self, char *bitfile_name, u32 start_address);
+int local_backup_flash(llio_t *self, char *bitfile_name);
 void open_spi_access_local(llio_t *self);
 void close_spi_access_local(llio_t *self);
 

--- a/eeprom_remote.c
+++ b/eeprom_remote.c
@@ -99,6 +99,10 @@ int remote_backup_flash(llio_t *self, char *bitfile_name) {
     return flash_backup(self, bitfile_name);
 }
 
+int remote_restore_flash(llio_t *self, char *bitfile_name) {
+    return flash_restore(self, bitfile_name);
+}
+
 void open_spi_access_remote(llio_t *self) {
     (void)self;
     eeprom_access.read_page = &read_page;

--- a/eeprom_remote.c
+++ b/eeprom_remote.c
@@ -95,6 +95,10 @@ int remote_verify_flash(llio_t *self, char *bitfile_name, u32 start_address) {
     return eeprom_verify(self, bitfile_name, start_address);
 }
 
+int remote_backup_flash(llio_t *self, char *bitfile_name) {
+    return flash_backup(self, bitfile_name);
+}
+
 void open_spi_access_remote(llio_t *self) {
     (void)self;
     eeprom_access.read_page = &read_page;

--- a/eeprom_remote.h
+++ b/eeprom_remote.h
@@ -23,6 +23,7 @@
 
 int remote_write_flash(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int remote_verify_flash(llio_t *self, char *bitfile_name, u32 start_address);
+int remote_backup_flash(llio_t *self, char *bitfile_name);
 void open_spi_access_remote(llio_t *self);
 void close_spi_access_remote(llio_t *self);
 

--- a/eeprom_remote.h
+++ b/eeprom_remote.h
@@ -24,6 +24,7 @@
 int remote_write_flash(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
 int remote_verify_flash(llio_t *self, char *bitfile_name, u32 start_address);
 int remote_backup_flash(llio_t *self, char *bitfile_name);
+int remote_restore_flash(llio_t *self, char *bitfile_name);
 void open_spi_access_remote(llio_t *self);
 void close_spi_access_remote(llio_t *self);
 

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -176,9 +176,9 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
-
             board->open = &eth_board_open;
             board->close = &eth_board_close;
             board->print_info = &eth_print_info;
@@ -202,6 +202,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -226,6 +227,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -250,6 +252,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -275,6 +278,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -298,6 +302,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -321,6 +326,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -346,6 +352,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -371,6 +378,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -398,6 +406,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -425,6 +434,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -449,6 +459,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write = &eth_write;
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
+            board->llio.backup_flash = &remote_backup_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;

--- a/eth_boards.c
+++ b/eth_boards.c
@@ -177,6 +177,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -203,6 +204,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -228,6 +230,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -253,6 +256,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -279,6 +283,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -303,6 +308,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -327,6 +333,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -353,6 +360,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -379,6 +387,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -407,6 +416,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -435,6 +445,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;
@@ -460,6 +471,7 @@ static int eth_scan_one_addr(board_access_t *access) {
             board->llio.write_flash = &remote_write_flash;
             board->llio.verify_flash = &remote_verify_flash;
             board->llio.backup_flash = &remote_backup_flash;
+            board->llio.restore_flash = &remote_restore_flash;
             board->llio.reset = &lbp16_board_reset;
             board->llio.reload = &lbp16_board_reload;
             board->open = &eth_board_open;

--- a/hostmot2.h
+++ b/hostmot2.h
@@ -55,6 +55,7 @@ struct llio_struct {
     int (*write)(llio_t *self, u32 addr, void *buffer, int size);
     int (*write_flash)(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
     int (*verify_flash)(llio_t *self, char *bitfile_name, u32 start_address);
+    int (*backup_flash)(llio_t *self, char *bitfile_name);
     int (*program_fpga)(llio_t *self, char *bitfile_name);
     int (*reset)(llio_t *self);
     int (*reload)(llio_t *self, int fallback_flag);

--- a/hostmot2.h
+++ b/hostmot2.h
@@ -56,6 +56,7 @@ struct llio_struct {
     int (*write_flash)(llio_t *self, char *bitfile_name, u32 start_address, int fix_boot_flag);
     int (*verify_flash)(llio_t *self, char *bitfile_name, u32 start_address);
     int (*backup_flash)(llio_t *self, char *bitfile_name);
+    int (*restore_flash)(llio_t *self, char *bitfile_name);
     int (*program_fpga)(llio_t *self, char *bitfile_name);
     int (*reset)(llio_t *self);
     int (*reload)(llio_t *self, int fallback_flag);

--- a/mesaflash.c
+++ b/mesaflash.c
@@ -122,7 +122,7 @@ void print_usage() {
     printf("  mesaflash --device device_name [options] --write filename\n");
     printf("  mesaflash --device device_name [options] --verify filename\n");
     printf("  mesaflash --device device_name [options] --program filename\n");
-    printf("  mesaflash --device device_name [options] --backup-flash filename | auto\n");
+    printf("  mesaflash --device device_name [options] --backup-flash filename | dirname\n");
     printf("  mesaflash --device device_name [options] --restore-flash filename\n");
     printf("  mesaflash --device device_name [options] --readhmid\n");
     printf("  mesaflash --device device_name [options] --reload | --reset\n");

--- a/mesaflash.c
+++ b/mesaflash.c
@@ -173,7 +173,7 @@ void print_usage() {
     printf("                    the FPGA (IMPORTANT! 'filename' must be VALID FPGA\n");
     printf("                    configuration file).\n");
     printf("  --backup-flash    Backup all content the FLASH memory to the file 'filename'.\n");
-    printf("  --restore-flash   Restore all content the FLASH memory from a file 'filename'\n");
+    printf("  --restore-flash   Restore all content the FLASH memory from a file 'filename'.\n");
     printf("  --readhmid        Print hostmot2 configuration in PIN file format.\n");
     printf("  --print-pd        Print hostmot2 Pin Descriptors.\n");
     printf("  --reload          Do full FPGA reload from flash (only Ethernet, SPI and\n");

--- a/mesaflash.c
+++ b/mesaflash.c
@@ -41,6 +41,7 @@ static int addr_hi_flag;
 static int write_flag;
 static int fix_boot_flag;
 static int verify_flag;
+static int backup_flash_flag;
 static int auto_verify_flag = 1;
 static int fallback_flag;
 static int recover_flag;
@@ -78,6 +79,7 @@ static struct option long_options[] = {
     {"no-auto-verify", no_argument, &auto_verify_flag, 0},
     {"fix-boot-block", no_argument, &fix_boot_flag, 1},
     {"verify", required_argument, 0, 'v'},
+    {"backup-flash", required_argument, 0, 'f'},
     {"fallback", no_argument, &fallback_flag, 1},
     {"recover", no_argument, &recover_flag, 1},
     {"program", required_argument, 0, 'p'},
@@ -118,6 +120,7 @@ void print_usage() {
     printf("  mesaflash --device device_name [options] --write filename\n");
     printf("  mesaflash --device device_name [options] --verify filename\n");
     printf("  mesaflash --device device_name [options] --program filename\n");
+    printf("  mesaflash --device device_name [options] --backup-flash filename | auto\n");
     printf("  mesaflash --device device_name [options] --readhmid\n");
     printf("  mesaflash --device device_name [options] --reload | --reset\n");
     printf("  mesaflash --device device_name [options] --sserial\n");
@@ -156,16 +159,17 @@ void print_usage() {
     printf("\n");
     printf("Commands:\n");
     printf("  --write           Writes a standard bitfile 'filename' configuration to\n");
-    printf("                    the userarea of the EEPROM (IMPORTANT! 'filename' must\n");
+    printf("                    the userarea of the FLASH (IMPORTANT! 'filename' must\n");
     printf("                    be VALID FPGA configuration file).\n");
     printf("  --fix-boot-block  If a write operation does not detect a valid boot\n");
     printf("                    block, write one.\n");
     printf("  --no-auto-verify  Don't automatically verify after writing.\n");
-    printf("  --verify          Verifies the EEPROM configuration against the\n");
+    printf("  --verify          Verifies the FLASH configuration against the\n");
     printf("                    bitfile 'filename'.\n");
     printf("  --program         Writes a standard bitfile 'filename' configuration to\n");
     printf("                    the FPGA (IMPORTANT! 'filename' must be VALID FPGA\n");
     printf("                    configuration file).\n");
+    printf("  --backup-flash    Backup all content the FLASH memory to the file 'filename'.\n");
     printf("  --readhmid        Print hostmot2 configuration in PIN file format.\n");
     printf("  --print-pd        Print hostmot2 Pin Descriptors.\n");
     printf("  --reload          Do full FPGA reload from flash (only Ethernet, SPI and\n");
@@ -345,6 +349,21 @@ int process_cmd_line(int argc, char *argv[]) {
             }
             break;
 
+            case 'f': {
+                if (backup_flash_flag > 0) {
+                    printf("Error: multiple --backup-flash options\n");
+                    exit(-1);
+                }
+                size_t len = strlen(optarg);
+                if (len+1 > sizeof(bitfile_name)) {
+                    printf("--backup-flash argument too long (max %zu)\n", sizeof(bitfile_name)-1);
+                    return 1;
+                }
+                strncpy(bitfile_name, optarg, 255);
+                backup_flash_flag++;
+            }
+            break;
+
             case 'i': {
                 if (info_flag > 0) {
                     printf("Error: multiple --info options\n");
@@ -480,6 +499,8 @@ int main(int argc, char *argv[]) {
             }
         } else if (verify_flag == 1) {
             ret = anyio_dev_verify_flash(board, bitfile_name, fallback_flag);
+        } else if (backup_flash_flag == 1) {
+            ret = anyio_dev_backup_flash(board, bitfile_name);
         } else if (program_flag == 1) {
             ret = anyio_dev_program_fpga(board, bitfile_name);
         } else if (reload_flag == 1) {


### PR DESCRIPTION
--backup-flash command for make full dump flash memory
--restore-flash command for restore flash memory from dump file
These commads active only for ethernet boards, for local type boards need activate them.
Memory dump file can also be used to write directly to flash memory, using the spi flash programmer(may be needed for repair brick board).
Tested only on 7I93 board.