### PR TITLE
Add a debian packaging workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,22 @@ jobs:
         dch -l+`git rev-parse --short HEAD` "actions package build"
         debuild -b
 
+  test-package:
+    strategy:
+      matrix:
+        os: ["buster", "bullseye"]
+        cpu: ["i386", "amd64", "armhf", "aarch64"]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Debian package
+      uses: dawidd6/action-debian-package@v1
+      with:
+        source_directory: .
+        artifacts_directory: output
+        os_distribution: ${{ matrix.os }}
+        cpu_architecture: ${{ matrix.cpu }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,21 @@ jobs:
         cpu: ["i386", "amd64", "armhf", "aarch64"]
     runs-on: ubuntu-20.04
     steps:
+    - name: Install deps
+      run: |
+        sudo apt-get update
+        sudo apt install -y --no-install-suggests --no-install-recommends devscripts
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Update debian changelog
+      env:
+        OS_RELEASE: ${{ matrix.os }}
+      run: |
+        git checkout HEAD -- debian/changelog
+        ref=`git describe --tags --always | sed -e 's/^release\///;s/^v//;s/-/+/g'`
+        DEBEMAIL=noreply@github.com dch -v "${ref}+${OS_RELEASE}-1" "Build from github actions"
+        head debian/changelog
     - name: Build Debian package
       uses: dawidd6/action-debian-package@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ ifeq ($(TARGET),linux)
     ifeq ($(UNAME_M),aarch64)
         MESAFLASH_IO ?= 0
     endif
+    ifeq ($(UNAME_M),armv7l)
+	ifeq ($(wildcard /usr/include/arm-linux-gnueabihf/asm/io.h),)
+        MESAFLASH_IO ?= 0
+	endif
+    endif
 endif
 
 ifeq ($(TARGET),windows)


### PR DESCRIPTION
Over in #61 use of a new library is being used, but it was not listed in the debian packaging. This would have detected the problem during Actions CI.