### PR TITLE
switch from openssl to libmd for sha256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,18 +56,18 @@ ifeq ($(TARGET),linux)
         $(error "pkg-config can't find libpci")
     endif
 
-    $(shell pkg-config --exists libcrypto > /dev/null)
+    $(shell pkg-config --exists libmd > /dev/null)
     ifeq ($(.SHELLSTATUS), 1)
-        $(error "pkg-config can't find libcrypto")
+        $(error "pkg-config can't find libmd")
     endif
 
     LIBPCI_CFLAGS := $(shell pkg-config --cflags libpci)
     LIBPCI_LDFLAGS := $(shell pkg-config --libs libpci)
-    LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto)
-    LIBCRYPTO_LDFLAGS := $(shell pkg-config --libs libcrypto)
+    LIBMD_CFLAGS := $(shell pkg-config --cflags libmd)
+    LIBMD_LDFLAGS := $(shell pkg-config --libs libmd)
     BIN = mesaflash
-    LDFLAGS = -lm $(LIBPCI_LDFLAGS) $(LIBCRYPTO_LDFLAGS)
-    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS) $(LIBCRYPTO_CFLAGS) -D_FILE_OFFSET_BITS=64
+    LDFLAGS = -lm $(LIBPCI_LDFLAGS) $(LIBMD_LDFLAGS)
+    CFLAGS += -D_GNU_SOURCE $(LIBPCI_CFLAGS) $(LIBMD_CFLAGS) -D_FILE_OFFSET_BITS=64
 
     UNAME_M := $(shell uname -m)
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Priority: optional
 Standards-Version: 3.9.4
 Build-Depends: debhelper (>= 9),
                libpci-dev,
-               libssl-dev,
+               libmd-dev,
                pkg-config
 Homepage: https://github.com/LinuxCNC/mesaflash
 Vcs-Browser: https://github.com/linuxcnc/mesaflash

--- a/eeprom.c
+++ b/eeprom.c
@@ -23,7 +23,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <strings.h>
-#include <openssl/sha.h>
+#include <sha256.h>
 #include <stdbool.h>
 #include <linux/limits.h>
 #include "types.h"
@@ -221,7 +221,7 @@ bool sha256_verify(const char *bitfile_name, bool verbose) {
     SHA256_Init(&sha256ctx);
     while (!feof(fp)) {
         bytesread = fread(&file_buffer, 1, 8192, fp);
-        SHA256_Update(&sha256ctx, &file_buffer, (unsigned long)bytesread);
+        SHA256_Update(&sha256ctx, file_buffer, (unsigned long)bytesread);
     }
     fclose(fp);
     SHA256_Final(sha256bitfile, &sha256ctx);
@@ -477,7 +477,7 @@ int flash_backup(llio_t *self, char *bitfile_name) {
         eeprom_access.read_page(self, eeprom_addr, &page_buffer);
 
         fwrite(&page_buffer, 1, PAGE_SIZE, fp);
-        SHA256_Update(&sha256ctx, &page_buffer, PAGE_SIZE);
+        SHA256_Update(&sha256ctx, page_buffer, PAGE_SIZE);
 
         eeprom_addr += PAGE_SIZE;
         page_num++;


### PR DESCRIPTION
Some versions of openssl are perceived to have a problematic
(non-GPL-compatible) license.  For example, lintian in Debian 11 Bullseye
rejects GPL programs linked with openssl:

    E: mesaflash: possible-gpl-code-linked-with-openssl

This commit switches from using openssl to using libmd for SHA256
computation, which does not have this problem (and which is arguably
preferable for being lighter-weight and more focused than openssl).

Note: a slight difference in the APIs of the two implementations requires
the slightly different arguments to SHA256_Update():

    openssl:

        int SHA256_Update(SHA256_CTX *c, const void *data, size_t len);

    libmd:

        void SHA256_Update(SHA25_CTX *, const uint8_t *, size_t);