### PR TITLE
.deb: Indicate mesaflash needs root to build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 9),
                libpci-dev,
                libmd-dev,
                pkg-config
+Rules-Requires-Root: binary-targets
 Homepage: https://github.com/LinuxCNC/mesaflash
 Vcs-Browser: https://github.com/linuxcnc/mesaflash
 Vcs-Git: https://github.com/LinuxCNC/mesaflash.git -b master


### PR DESCRIPTION
During a test rebuild for building packages with
`Rules-Requires-Root: no` as the default in `dpkg`, mesaflash failed to rebuild.

Per the FAQ how to handle packages using static ownership, indicate we don't support building without root.